### PR TITLE
feat: update brotli to 1.1.0rc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - '**/*.gitignore'
       - .editorconfig
       - docs/**
-jobs: 
+jobs:
   Linux:
     name: Test on Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,27 @@ jobs:
         with:
           # 等同于 run: git submodule update --init --recursive
           submodules: recursive
+      # On Mac, when Node.js v14 + Python v3.11, node-gyp compilation reports an error:
+      # ValueError: invalid mode: 'rU' while trying to load binding.gyp
+      # See https://github.com/iotaledger/wallet.rs/pull/1613
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Python verison
+        run: python --version
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
-          cache: yarn
+          cache: npm
       - name: Install dependencies
-        run: yarn install
+        run: npm install
+      - name: Build bindings
+        run: npm run build
       - name: Test bindings
-        run: yarn test
+        run: npm test
 
   macOS:
     name: Test on macOS
@@ -43,12 +55,21 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Python verison
+        run: python --version
+
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
-          cache: yarn
+          cache: npm
       - name: Install dependencies
-        run: yarn install
+        run: npm install
+      - name: Build bindings
+        run: npm run build
       - name: Test bindings
-        run: yarn test
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [14, 16, 18, 20]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,7 +38,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node: [14, 16, 18]
+        node: [14, 16, 18, 20]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules/
 build/
 .nyc_output/
+
 .DS_Store
+
+builderror.log

--- a/README.md
+++ b/README.md
@@ -85,3 +85,10 @@ fs.writeFileSync(output, woff2.encode(input));
 In order to use the development env, install [Nix](https://nixos.org/nix/) and
 run `nix-shell` in the root of this repo. You will be dropped into a shell with
 the project's dependencies installed.
+
+## Node-gyp build
+
+```shell
+npm run build
+npm test
+```

--- a/binding.gyp
+++ b/binding.gyp
@@ -56,21 +56,21 @@
         "./woff2/brotli/c/include",
         "./woff2/include"
       ],
-      "cflags": ["-std=c++14 -w"],
+      "cflags": ["-std=c++17 -w"],
       "conditions": [
         [
           "OS!=\"win\"",
           {
-            "cflags+": ["-std=c++14"],
-            "cflags_c+": ["-std=c++14"],
-            "cflags_cc+": ["-std=c++14"]
+            "cflags+": ["-std=c++17"],
+            "cflags_c+": ["-std=c++17"],
+            "cflags_cc+": ["-std=c++17"]
           }
         ],
         [
           "OS==\"mac\"",
           {
             "xcode_settings": {
-              "OTHER_CPLUSPLUSFLAGS": ["-std=c++14", "-stdlib=libc++", "-w"],
+              "OTHER_CPLUSPLUSFLAGS": ["-std=c++17", "-stdlib=libc++", "-w"],
               "OTHER_LDFLAGS": ["-stdlib=libc++"],
               "MACOSX_DEPLOYMENT_TARGET": "10.7"
             }
@@ -133,21 +133,21 @@
         "./woff2/brotli/c/include",
         "./woff2/include"
       ],
-      "cflags": ["-std=c++14 -w"],
+      "cflags": ["-std=c++17 -w"],
       "conditions": [
         [
           "OS!=\"win\"",
           {
-            "cflags+": ["-std=c++14"],
-            "cflags_c+": ["-std=c++14"],
-            "cflags_cc+": ["-std=c++14"]
+            "cflags+": ["-std=c++17"],
+            "cflags_c+": ["-std=c++17"],
+            "cflags_cc+": ["-std=c++17"]
           }
         ],
         [
           "OS==\"mac\"",
           {
             "xcode_settings": {
-              "OTHER_CPLUSPLUSFLAGS": ["-std=c++14", "-stdlib=libc++", "-w"],
+              "OTHER_CPLUSPLUSFLAGS": ["-std=c++17", "-stdlib=libc++", "-w"],
               "OTHER_LDFLAGS": ["-stdlib=libc++"],
               "MACOSX_DEPLOYMENT_TARGET": "10.7"
             }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Node wrapper around Google's woff2 utility.",
   "main": "./src/woff2.js",
   "scripts": {
+    "build": "((node-gyp configure && node-gyp build) > builderror.log) || (exit 0)",
     "lint": "npm run run-eslint && npm run run-prettier",
     "run-eslint": "eslint **/*.js",
     "run-prettier": "prettier --write **/*.{js,json,md,gyp,yml}",
@@ -30,7 +31,7 @@
   ],
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.15.0"
+    "nan": "^2.17.0"
   },
   "devDependencies": {
     "eslint": "8.13.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.29.4",
     "font-awesome": "4.7.0",
-    "mmmagic": "0.5.3",
     "node-gyp": "^9.0.0",
     "prettier": "2.6.2",
     "tap": "16.0.1",


### PR DESCRIPTION
And

- test: adding Node.js v20 to CI
- fix: invalid mode: 'rU' while trying to load binding.gyp
  On Mac, when Node.js v14 + Python v3.11, node-gyp compilation reports an error:
  `ValueError: invalid mode: 'rU' while trying to load binding.gyp`
   See https://github.com/iotaledger/wallet.rs/pull/1613